### PR TITLE
feat(SimpleTokenSwap): adds forked 0x ExchangeProxy to check against …

### DIFF
--- a/contracts/SimpleTokenSwap.sol
+++ b/contracts/SimpleTokenSwap.sol
@@ -23,9 +23,13 @@ contract SimpleTokenSwap {
     IWETH public immutable WETH;
     // Creator of this contract.
     address public owner;
+    // 0x ExchangeProxy address.
+    // See https://docs.0x.org/developer-resources/contract-addresses
+    address public exchangeProxy;
 
-    constructor(IWETH weth) {
-        WETH = weth;
+    constructor(IWETH _weth, address _exchangeProxy) {
+        WETH = _weth;
+        exchangeProxy = _exchangeProxy;
         owner = msg.sender;
     }
 
@@ -78,6 +82,9 @@ contract SimpleTokenSwap {
         onlyOwner
         payable // Must attach ETH equal to the `value` field from the API response.
     {
+        // Checks that the swapTarget is actually the address of 0x ExchangeProxy
+        require(swapTarget == exchangeProxy, "Target not ExchangeProxy");
+
         // Track our balance of the buyToken to determine how much we've bought.
         uint256 boughtAmount = buyToken.balanceOf(address(this));
 

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -4,7 +4,7 @@ const SimpleTokenSwap = artifacts.require('SimpleTokenSwap');
 const CONFIG = require('../truffle-config');
 
 module.exports = function (deployer, network) {
-    deployer.deploy(SimpleTokenSwap, CONFIG.networks[network].weth)
+    deployer.deploy(SimpleTokenSwap, CONFIG.networks[network].weth, CONFIG.networks[network].exchange_proxy)
         .then(deployed => {
             if (network.startsWith('forked-')) {
                 // Update the forked deployed address in package.json.

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -37,8 +37,8 @@ module.exports = {
         goerli: {
             provider: () => new HDWalletProvider(MNEMONIC, RPC_URL),
             network_id: 5,
-            weth: '0x0bb7509324ce409f7bbc4b701f932eaca9736ab7',
-            exchange_proxy: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF",
+            weth: '0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6',
+            exchange_proxy: "0xf91bb752490473b8342a3e964e855b9f9a2a668e",
         },
     },
 

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -18,6 +18,7 @@ module.exports = {
             port: 8545,
             network_id: '*',
             weth: '0x0000000000000000000000000000000000000000',
+            exchange_proxy: '0x0000000000000000000000000000000000000000',
         },
         'forked-mainnet': {
             host: 'localhost',
@@ -25,21 +26,19 @@ module.exports = {
             network_id: '1',
             skipDryRun: true,
             weth: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            exchange_proxy: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF",
         },
         mainnet: {
             provider: () => new HDWalletProvider(MNEMONIC, RPC_URL),
             network_id: '1',
             weth: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            exchange_proxy: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF",
         },
-        ropsten: {
+        goerli: {
             provider: () => new HDWalletProvider(MNEMONIC, RPC_URL),
-            network_id: 3,
-            weth: '0xc778417e063141139fce010982780140aa0cd5ab',
-        },
-        kovan: {
-            provider: () => new HDWalletProvider(MNEMONIC, RPC_URL),
-            network_id: 42,
-            weth: '0xd0a1e359811322d97991e03f863a0c30c2cf029c',
+            network_id: 5,
+            weth: '0x0bb7509324ce409f7bbc4b701f932eaca9736ab7',
+            exchange_proxy: "0xDef1C0ded9bec7F1a1670819833240f027b25EfF",
         },
     },
 


### PR DESCRIPTION
- Adds `exchangeProxy` state on `SimpleTokenSwap`, which is set on the constructor to point to the [0x ExchangeProxy contract address](https://docs.0x.org/developer-resources/contract-addresses). This is used on `fillQuote` to check against `swapTarget`. Users must know that the actual `to` response of the 0x Swap Api is the `ExchangeProxy`. On production, this could lead to exploits. Better to leave it over-explained on the guide.
- Removes ropsten and kovan from truffle config and replaces it with goerli