### PR TITLE
Update SimpleTokenSwap.sol

### DIFF
--- a/contracts/SimpleTokenSwap.sol
+++ b/contracts/SimpleTokenSwap.sol
@@ -41,7 +41,7 @@ contract SimpleTokenSwap {
     // Payable fallback to allow this contract to receive protocol fee refunds.
     receive() external payable {}
 
-    // Transfer tokens held by this contrat to the sender/owner.
+    // Transfer tokens held by this contract to the sender/owner.
     function withdrawToken(IERC20 token, uint256 amount)
         external
         onlyOwner
@@ -49,7 +49,7 @@ contract SimpleTokenSwap {
         require(token.transfer(msg.sender, amount));
     }
 
-    // Transfer ETH held by this contrat to the sender/owner.
+    // Transfer ETH held by this contract to the sender/owner.
     function withdrawETH(uint256 amount)
         external
         onlyOwner


### PR DESCRIPTION
Fixed typos, worth also noting that  `require(sellToken.approve(spender, uint256(-1)));` cant be used from >0.8.0. Users should declare a max constant as a member variable and pass that instead something like: 
```
    // as a member on the contract
    uint256 public constant MASK = type(uint128).max;

    ....
    require(sellToken.approve(spender, MASK), "approve failed");
```